### PR TITLE
fix: unify SQLAlchemy Base

### DIFF
--- a/snu_toto/alembic/env.py
+++ b/snu_toto/alembic/env.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.getcwd(), "snu_toto"))
 
 
 # Alembic을 통해 인식돼야 하는 모델
-from app.core.database import Base
+from snu_toto.app.core.database import Base # 모든 models.py가 동일한 절대 경로를 사용해야 Base를 같은 것으로 인식
 from app.core.config import DB_SETTINGS
 from app.users.models import User, PointHistory
 from app.events.models import Event, EventOption, EventImage
@@ -29,6 +29,11 @@ config.set_main_option("sqlalchemy.url", DB_SETTINGS.url)
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# 디버깅용
+# print("--- 로드된 테이블 목록 ---")
+# print(Base.metadata.tables.keys())
+# print("-----------------------")
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/snu_toto/app/bets/models.py
+++ b/snu_toto/app/bets/models.py
@@ -2,12 +2,12 @@ import enum
 import uuid
 from sqlalchemy import String, Integer, DateTime, Enum, ForeignKey, func, CheckConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from app.core.database import Base
+from snu_toto.app.core.database import Base
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.users.models import User, PointHistory
-    from app.events.models import Event, EventOption
+    from snu_toto.app.users.models import User, PointHistory
+    from snu_toto.app.events.models import Event, EventOption
 
 class BetStatus(str, enum.Enum):
     """베팅 상태를 위한 Enum"""
@@ -70,7 +70,6 @@ class Bet(Base):
     )
 
     user: Mapped["User"] = relationship("User", back_populates="bets")
-    point_histories: Mapped[list["PointHistory"]] = relationship("PointHistory", back_populates="bet")
     option: Mapped["EventOption"] = relationship("EventOption", back_populates="bets")
     event: Mapped["Event"] = relationship("Event", back_populates="bets")
 

--- a/snu_toto/app/events/models.py
+++ b/snu_toto/app/events/models.py
@@ -2,12 +2,12 @@ import enum
 import uuid
 from sqlalchemy import String, Integer, DateTime, Boolean, Enum, ForeignKey, Text, func, CheckConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from app.core.database import Base
+from snu_toto.app.core.database import Base
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.users.models import User
-    from app.bets.models import Bet
+    from snu_toto.app.users.models import User
+    from snu_toto.app.bets.models import Bet
 
 class EventStatus(str, enum.Enum):
     """이벤트 상태를 위한 Enum"""

--- a/snu_toto/app/main.py
+++ b/snu_toto/app/main.py
@@ -7,7 +7,11 @@ from fastapi.exception_handlers import request_validation_exception_handler
 
 from .core.database import engine
 from .core.config import SETTINGS
-from .common.exceptions import SnutotoException, MissingRequiredFieldException
+from .common.exceptions import SnutotoException, MissingRequiredFieldException, InvalidFormatException
+
+from snu_toto.app.users import models as user_models
+from snu_toto.app.events import models as event_models
+from snu_toto.app.bets import models as bet_models
 
 
 @asynccontextmanager

--- a/snu_toto/app/users/models.py
+++ b/snu_toto/app/users/models.py
@@ -2,12 +2,12 @@ import enum
 import uuid
 from sqlalchemy import String, Integer, DateTime, Boolean, Enum, ForeignKey, func, CheckConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from app.core.database import Base
-from typing import TYPE_CHECKING
+from snu_toto.app.core.database import Base
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from app.bets.models import Bet
-    from app.events.models import Event
+    from snu_toto.app.bets.models import Bet
+    from snu_toto.app.events.models import Event
 
 class UserRole(str, enum.Enum):
     """관리자 여부를 위한 Enum"""
@@ -148,4 +148,3 @@ class PointHistory(Base):
     ) 
 
     user: Mapped["User"] = relationship("User", back_populates="point_histories")
-    bet: Mapped["Bet | None"] = relationship("Bet", back_populates="point_histories")


### PR DESCRIPTION
alembic에서 테이블 제대로 인식하지 못하는 문제 해결했습니다
(env.py와 models.py에서 Base를 같은 절대경로로 import하면 해결된다고 합니다)

db에서 point_history와 bets의 relationship을 제거했습니다(point_history의 bet_id가 정확히는 FK가 아니어서 문제가 생겼었습니다)

