### PR TITLE
fix: auto-update timestamps on status transition

### DIFF
--- a/snu_toto/app/events/repositories.py
+++ b/snu_toto/app/events/repositories.py
@@ -91,9 +91,13 @@ class EventRepositories:
         await self.session.refresh(event)
         return event
 
-    async def update_event_status(self, event_id: str, new_status: EventStatus) -> None:
-        """이벤트의 상태를 업데이트"""
-        result = await self.session.execute(update(Event).where(Event.event_id == event_id).values(status=new_status))
+    async def update_event_fields(self, event_id: str, update_data: dict) -> None:
+        """이벤트의 여러 필드를 한 번에 업데이트 (status, start_at, end_at 등)"""
+        result = await self.session.execute(
+            update(Event)
+            .where(Event.event_id == event_id)
+            .values(**update_data)
+        )
         
         # rowcount를 통해 실제 업데이트된 행이 있는지 확인
         if result.rowcount <= 0:

--- a/snu_toto/app/events/services.py
+++ b/snu_toto/app/events/services.py
@@ -359,15 +359,26 @@ class EventServices:
         }
         if new_status not in allowed_map.get(current_status, []):
             raise InvalidStatusTransitionError()
+        
+        # 상태에 따른 시간 업데이트 값 설정
+        update_data = {"status": new_status}
+        
+        # OPEN으로 변경 시: 시작 시각을 현재로
+        if new_status == EventStatus.OPEN:
+            update_data["start_at"] = datetime.now()
+        
+        # CLOSED로 변경 시: 종료 시각을 현재로
+        elif new_status == EventStatus.CLOSED:
+            update_data["end_at"] = datetime.now()
 
         session = self.event_repositories.session
 
         if not session.in_transaction():
             async with session.begin():
-                await self.event_repositories.update_event_status(event_id, new_status)
+                await self.event_repositories.update_event_fields(event_id, update_data)
         else:
-            await self.event_repositories.update_event_status(event_id, new_status)
-            await session.flush() # 변경 사항을 현재 트랜잭션에 반영 (커밋은 호출자가 관리)
+            await self.event_repositories.update_event_fields(event_id, update_data)
+            await session.flush()
     
     async def settle_event(self, event_id: str, winner_option_ids: List[str]) -> Event:
         """이벤트 결과 확정 및 포인트 정산 실행"""


### PR DESCRIPTION
관리자 수동 이벤트 상태 변경시 그에 맞게 이벤트 시간 정보를 DB에 수정해서 저장
