### PR TITLE
Feat/delete user and event

### DIFF
--- a/snu_toto/app/test_data/router.py
+++ b/snu_toto/app/test_data/router.py
@@ -247,6 +247,7 @@ async def delete_user_by_email(
     - 사용자가 생성한 이벤트 (및 해당 이벤트의 좋아요, 베팅, 댓글, 옵션)
     - 사용자의 베팅
     - 사용자의 좋아요
+    - 사용자가 작성한 댓글
     - 사용자 자체
     """
     try:
@@ -301,6 +302,12 @@ async def delete_user_by_email(
         
         # 사용자의 좋아요 삭제
         await db.execute(delete(EventLike).where(EventLike.user_id == user_id))
+        
+        # 사용자가 작성한 댓글 삭제 (다른 이벤트에 작성한 댓글)
+        try:
+            await db.execute(delete(Comment).where(Comment.user_id == user_id))
+        except:
+            pass
         
         # 사용자 삭제
         await db.execute(delete(User).where(User.user_id == user_id))


### PR DESCRIPTION
**특정 이메일의 사용자와 관련 데이터를 삭제**
    
- email: 삭제할 사용자의 이메일

삭제되는 데이터:
- 사용자가 생성한 이벤트 (및 해당 이벤트의 좋아요, 베팅, 댓글, 옵션)
- 사용자의 베팅
- 사용자의 좋아요
- 사용자가 작성한 댓글
- 사용자 자체
    
    
**특정 ID의 이벤트와 관련 데이터를 삭제**
    
- event_id: 삭제할 이벤트의 ID

삭제되는 데이터:
- 이벤트에 연결된 좋아요
- 이벤트에 연결된 베팅
- 이벤트에 연결된 댓글
- 이벤트 옵션
- 이벤트 자체