### PR TITLE
Fix/delete user event

### DIFF
--- a/snu_toto/app/test_data/router.py
+++ b/snu_toto/app/test_data/router.py
@@ -339,7 +339,7 @@ async def delete_user_by_email(
 
 @router.delete("/events/{event_id}")
 async def delete_event_by_id(
-    event_id: int,
+    event_id: str,
     db: AsyncSession = Depends(get_db_session)
 ):
     """


### PR DESCRIPTION
- DELETE /api/test/users/by-email/{email} : 삭제 과정에서 DB에서 발생하는 오류 해결
- DELETE /api/test/events/{event_id} : event_id를 str이 아닌 int로 받는 오타 수정