### PR TITLE
Fix/delete user event 2

### DIFF
--- a/snu_toto/app/test_data/router.py
+++ b/snu_toto/app/test_data/router.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from redis.asyncio import Redis
 from snu_toto.app.auth.dependencies import get_redis
 from snu_toto.app.core.database import get_db_session, engine, Base
-from snu_toto.app.users.models import User
+from snu_toto.app.users.models import PointHistory, User
 from snu_toto.app.events.models import Event, EventStatus
 from snu_toto.app.bets.models import Bet
 
@@ -339,7 +339,7 @@ async def delete_user_by_email(
 
 @router.delete("/events/{event_id}")
 async def delete_event_by_id(
-    event_id: int,
+    event_id: str,
     db: AsyncSession = Depends(get_db_session)
 ):
     """


### PR DESCRIPTION
- DELETE /api/test/users/by-email/{email} : 삭제 과정에서 DB에서 발생하는 오류 해결
- DELETE /api/test/events/{event_id} : event_id를 str이 아닌 int로 받는 오타 수정