### PR TITLE
Feat/signup verify

### DIFF
--- a/snu_toto/app/main.py
+++ b/snu_toto/app/main.py
@@ -11,7 +11,7 @@ from snu_toto.app.core.database import engine
 from snu_toto.app.core.config import SETTINGS
 from snu_toto.app.common.exceptions import SnutotoException, MissingRequiredFieldException, InvalidFormatException
 from snu_toto.app.events.schedular import auto_update_event_status
-from snu_toto.app.users.scheduler import start_ranking_scheduler
+from snu_toto.app.users.scheduler import start_cleanup_scheduler, start_ranking_scheduler
 from snu_toto.app.users import models as user_models
 from snu_toto.app.events import models as event_models
 from snu_toto.app.bets import models as bet_models
@@ -23,6 +23,7 @@ async def lifespan(app: FastAPI):
     # 앱 시작 시
     task = asyncio.create_task(auto_update_event_status())
     ranking_scheduler = start_ranking_scheduler()
+    cleanup_scheduler = start_cleanup_scheduler()
 
     yield
 
@@ -30,6 +31,7 @@ async def lifespan(app: FastAPI):
     await engine.dispose()
     task.cancel()
     ranking_scheduler.shutdown()
+    cleanup_scheduler.shutdown()
 
 
 app = FastAPI(

--- a/snu_toto/app/users/repositories.py
+++ b/snu_toto/app/users/repositories.py
@@ -2,13 +2,14 @@ from typing import Annotated, Optional, List
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import and_, desc, func, or_, update
+from sqlalchemy import and_, delete, desc, func, or_, update
+from snu_toto.app.core.config import AUTH_SETTINGS
 from snu_toto.app.core.date_utils import get_kst_now
 from snu_toto.app.users.models import User, PointHistory, PointReason, UserWithdrawal
 from snu_toto.app.bets.models import Bet, BetStatus
 from snu_toto.app.events.models import Event, EventOption
 from snu_toto.app.core.database import get_db_session
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 class UserRepository:
@@ -375,3 +376,39 @@ class UserRepository:
         users = result.scalars().all()
 
         return users, total_count
+    
+    async def delete_expired_unverified_users(self, expiry_minutes: int = AUTH_SETTINGS.SHORT_SESSION_LIFESPAN + 5):
+        """생성된 지 n분이 지났으나 SNU 인증을 하지 않은 유저 삭제"""
+        expiry_time = get_kst_now() - timedelta(minutes=expiry_minutes)
+            
+        try:
+            # 삭제 대상 ID들
+            target_query = (
+                select(User.user_id)
+                .where(User.is_snu_verified == False)
+                .where(User.created_at < expiry_time)
+            )
+            result = await self.db.execute(target_query)
+            target_user_ids = result.scalars().all() # ID 리스트 확보
+
+            if not target_user_ids:
+                return 0
+
+            # PointHistory에서 해당 유저들의 기록 삭제
+            await self.db.execute(
+                delete(PointHistory)
+                .where(PointHistory.user_id.in_(target_user_ids))
+            )
+
+            # User 테이블에서 해당 유저들을 최종 삭제
+            delete_result = await self.db.execute(
+                delete(User)
+                .where(User.user_id.in_(target_user_ids))
+            )
+            
+            deleted_count = delete_result.rowcount
+            return deleted_count
+
+        except Exception as e:
+            print(f"[Cleanup Error] {e}")
+            raise e

--- a/snu_toto/app/users/router.py
+++ b/snu_toto/app/users/router.py
@@ -31,6 +31,7 @@ async def signup(
     user_in: UserSignupRequest, 
     user_service: UserService = Depends(get_user_service) 
 ) -> UserResponse:
+    """회원가입"""
     return await user_service.signup(user_in)
 
 @users_router.get("/me/bets", status_code=status.HTTP_200_OK)

--- a/snu_toto/app/users/scheduler.py
+++ b/snu_toto/app/users/scheduler.py
@@ -11,9 +11,13 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import select
 
 from snu_toto.app.core.config import DB_SETTINGS, REDIS_SETTINGS
+from snu_toto.app.core.database import AsyncSessionLocal
 from snu_toto.app.core.date_utils import get_kst_now
 from snu_toto.app.users.models import User
 from redis.asyncio import from_url
+
+from snu_toto.app.users.repositories import UserRepository
+from snu_toto.app.users.services import UserService
 
 
 async def update_all_rankings():
@@ -119,4 +123,35 @@ def start_ranking_scheduler():
     scheduler.start()
     print("[스케줄러] 랭킹 업데이트 스케줄러 시작됨 (매시 00분 실행)")
     
+    return scheduler
+
+async def run_ghost_user_cleanup():
+    """배치 작업 실행 함수"""
+    async with AsyncSessionLocal() as session:
+        # 서비스 수동 주입
+        repo = UserRepository(db=session)
+        service = UserService(db=session)
+        
+        try:
+            await service.cleanup_ghost_users()
+            await session.commit()
+        except Exception as e:
+            await session.rollback()
+            print(f"[Cleanup Error] {e}")
+
+def start_cleanup_scheduler():
+    """스케줄러 시작 (1분마다 실행)"""
+    scheduler = AsyncIOScheduler()
+    
+    # 1분마다 실행
+    scheduler.add_job(
+        run_ghost_user_cleanup,
+        'interval',
+        minutes=1,
+        id='cleanup_ghost_users',
+        replace_existing=True
+    )
+    
+    scheduler.start()
+    print("[스케줄러] 유령 유저 청소 스케줄러 시작됨 (1분 주기)")
     return scheduler

--- a/snu_toto/app/users/schemas.py
+++ b/snu_toto/app/users/schemas.py
@@ -45,6 +45,7 @@ class UserResponse(BaseModel):
     is_verified: bool = False
     social_type: SocialType = SocialType.LOCAL
     created_at: datetime
+    verification_token: Optional[str] = None
 
 # 참여 중인 베팅 내역 조회용 스키마
 class UserBetItem(BaseModel):

--- a/snu_toto/app/users/services.py
+++ b/snu_toto/app/users/services.py
@@ -9,7 +9,8 @@ from snu_toto.app.users.models import User, PointReason
 from snu_toto.app.users.schemas import (
     AdminUserListResponse,
     AdminUserResponse,
-    SocialType, 
+    SocialType,
+    UserResponse, 
     UserSignupRequest,
     UserBetsResponse,
     UserBetItem,
@@ -24,7 +25,7 @@ from snu_toto.app.users.schemas import (
     UpdatePasswordRequest,
     UpdatePasswordResponse
 )
-from snu_toto.app.core.security import get_email_hash, get_password_hash
+from snu_toto.app.core.security import create_verification_token, get_email_hash, get_password_hash
 from snu_toto.app.users.repositories import UserRepository
 from snu_toto.app.users.exceptions import (
     EmailAlreadyExistsException, 
@@ -39,7 +40,7 @@ class UserService:
         self.user_repo = UserRepository(db)
         self.db = db
 
-    async def signup(self, user_in: UserSignupRequest) -> User:
+    async def signup(self, user_in: UserSignupRequest) -> UserResponse:
         # 1. 재가입 제한 기간 확인 (30일)
         hashed_email = get_email_hash(user_in.email)
         withdrawal_record = await self.user_repo.get_latest_withdrawal_by_hash(hashed_email)
@@ -105,8 +106,24 @@ class UserService:
         except Exception as e:
             await self.db.rollback()
             raise e
+        
+        # 로컬 가입자(미인증 상태)인 경우에만 verification_token 생성
+        v_token = None
+        if not new_user.is_snu_verified:
+            v_token = create_verification_token(new_user.user_id)
             
-        return new_user
+        return UserResponse(
+            user_id=new_user.user_id,
+            email=new_user.email,
+            nickname=new_user.nickname,
+            points=new_user.points,
+            role=new_user.role,
+            is_snu_verified=new_user.is_snu_verified,
+            is_verified=new_user.is_verified,
+            social_type=new_user.social_type,
+            created_at=new_user.created_at,
+            verification_token=v_token
+        )
 
     async def get_my_bets(
         self,
@@ -284,4 +301,11 @@ class UserService:
                 total_pages=math.ceil(total_count / limit) if total_count > 0 else 0
             )
         )
+    
+    async def cleanup_ghost_users(self):
+        """유령 유저 청소 작업 수행"""
+        count = await self.user_repo.delete_expired_unverified_users(expiry_minutes=15)
+        if count > 0:
+            print(f"[Cleanup] {count}명의 미인증 유령 유저가 삭제되었습니다.")
+        return count
     


### PR DESCRIPTION
**스누메일 인증 관련 로직**

- 초기 가입 시 `is_snu_verified` 는 False로 설정됩니다(소셜로그인의 경우에는 자동으로 True로 설정)
- `is_snu_verified`가 `False`로 설정된 사용자는 로그인을 할 수 없습니다.
- 회원가입 직후 스누메일 인증 로직으로 이동합니다. (회원가입 성공 응답으로 받은 `verification_token` 사용)
- 만약 회원가입 직후 인증을 받지 못하면 로그인이 거부되며, 이때 다시 스누메일을 인증할 수 있습니다.
- **이메일 도용 가입 방지**: 만약 회원가입 직후로부터 스누메일을 인증받지 않은 상태로 약 15분이 지나면, `verification_token` 이 만료되며, 20분이 지나면 DB에서 해당 유저의 정보가 삭제됩니다. 따라서 해당 이메일로 서비스를 이용하기 위해서 회원가입을 처음부터 진행해야합니다.

> 참고: 사용자가 이메일 인증을 받을 수 있는 방법은 2가지가 있습니다.
>1. 회원가입 직후 자동으로 스누메일 인증 창으로 이동했을 때.
>2. (`1`에서 인증을 하지 않고 나간 경우) 로그인을 시도했지만 스누메일 인증 로직으로 이동했을 때.