### PR TITLE
fix: add my_total_bet_amount

### DIFF
--- a/snu_toto/app/events/schemas.py
+++ b/snu_toto/app/events/schemas.py
@@ -100,6 +100,7 @@ class EventDetailResponse(BaseModel):
     like_count: int
     is_liked: bool | None
     is_eligible: bool
+    my_total_bet_amount: int | None = None  # None: 로그인 안함, 0: 베팅 안함, >0: 총 베팅 금액
     options: list[OptionResponse]
     images: list[ImageResponse]
 

--- a/snu_toto/app/events/services.py
+++ b/snu_toto/app/events/services.py
@@ -185,11 +185,15 @@ class EventServices:
 
         # 유저의 베팅 정보 조회 (로그인한 경우)
         user_bet_map: dict[str, int] = {}  # option_id -> amount
+        my_total_bet_amount: int | None = None
         if user_id:
             bet_repo = BetRepositories(self.event_repositories.session)
             user_bet = await bet_repo.get_bet_by_user_and_event(user_id, event_id)
             if user_bet:
                 user_bet_map[user_bet.option_id] = user_bet.amount
+                my_total_bet_amount = user_bet.amount
+            else:
+                my_total_bet_amount = 0
 
         # 옵션별 배당률 계산 (유저 베팅 정보 포함)
         option_responses = [
@@ -230,6 +234,7 @@ class EventServices:
             like_count=like_count,
             is_liked=is_liked,
             is_eligible=event.is_eligible,
+            my_total_bet_amount=my_total_bet_amount,
             options=option_responses,
             images=image_responses
         )


### PR DESCRIPTION
event 상세 조회에 event 단위로 "my_total_bet_amount" 를 추가했습니다.

```
    {
      "event_id": "a30165e9-5f3e-4f0f-847f-2cdd55a60d93",
      "title": "OPEN 1일후종료",
      "description": "test",
      "status": "OPEN",
      "total_participants": 3,
      "created_at": "2026-02-03T22:53:42",
      "start_at": "2026-02-03T23:53:42",
      "end_at": "2026-02-07T23:53:42",
      "like_count": 5,
      "is_liked": true,
      "is_eligible": true,
      **"my_total_bet_amount": 0,**
      "options": [
        {
          "option_id": "bf5d0816-50e1-4578-9568-31e4077339d6",
          "name": "맑음",
          "option_total_amount": 0,
          "participant_count": 0,
          "odds": 0,
          "is_winner": null,
          "option_image_url": null,
          "my_bet_amount": 0
        }, ....
```